### PR TITLE
bump mypy to 0.720

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black==19.3b0
 codecov==2.0.15
 coverage==4.5.3
 isort==4.3.20
-mypy==0.701
+mypy==0.720
 pylint==2.3.1
 python-coveralls==2.9.2
 twine==1.13.0


### PR DESCRIPTION
### Bumping mypy version to 0.720

it fixed https://github.com/jreese/aiomultiprocess/issues/26

Fixes: Cause by dependencies of mypy, that was broken on mypy version. Current release works with 3.8
I ran `make test lint` on 3.7, it was fine, will let CI to run on 3.8.

Edit: 3.8 still fails with some other errors, I will look into it.