### PR TITLE
Set loop before running initializer

### DIFF
--- a/aiomultiprocess/core.py
+++ b/aiomultiprocess/core.py
@@ -129,11 +129,11 @@ class Process:
     def run_async(unit: Unit) -> R:
         """Initialize the child process and event loop, then execute the coroutine."""
         try:
-            if unit.initializer:
-                unit.initializer(*unit.initargs)
-
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
+
+            if unit.initializer:
+                unit.initializer(loop, *unit.initargs)
 
             result: R = loop.run_until_complete(unit.target(*unit.args, **unit.kwargs))
 

--- a/aiomultiprocess/core.py
+++ b/aiomultiprocess/core.py
@@ -133,7 +133,7 @@ class Process:
             asyncio.set_event_loop(loop)
 
             if unit.initializer:
-                unit.initializer(loop, *unit.initargs)
+                unit.initializer(*unit.initargs)
 
             result: R = loop.run_until_complete(unit.target(*unit.args, **unit.kwargs))
 

--- a/aiomultiprocess/tests/core.py
+++ b/aiomultiprocess/tests/core.py
@@ -27,7 +27,7 @@ async def starmapper(*values):
 DUMMY_CONSTANT = None
 
 
-def initializer(_loop, value):
+def initializer(value):
     global DUMMY_CONSTANT
 
     DUMMY_CONSTANT = value
@@ -165,12 +165,21 @@ class CoreTest(TestCase):
 
     @async_test
     async def test_async_initializer(self):
-        async def sleepy(_loop):
+        async def sleepy():
             await asyncio.sleep(0)
 
         with self.assertRaises(ValueError) as _:
             p = amp.Process(target=sleepy, name="test_process", initializer=sleepy)
             p.start()
+
+    @async_test
+    async def test_loop_in_initializer(self):
+        def dummy():
+            _loop = asyncio.get_event_loop()
+
+        p = amp.Process(target=two, name="test_process", initializer=dummy)
+        p.start()
+        await p.join()
 
     @async_test
     async def test_raise(self):
@@ -185,7 +194,7 @@ class CoreTest(TestCase):
 
     @async_test
     async def test_sync_target(self):
-        def dummy(_loop):
+        def dummy():
             pass
 
         with self.assertRaises(ValueError) as _:

--- a/aiomultiprocess/tests/core.py
+++ b/aiomultiprocess/tests/core.py
@@ -27,7 +27,7 @@ async def starmapper(*values):
 DUMMY_CONSTANT = None
 
 
-def initializer(value):
+def initializer(_loop, value):
     global DUMMY_CONSTANT
 
     DUMMY_CONSTANT = value
@@ -165,7 +165,7 @@ class CoreTest(TestCase):
 
     @async_test
     async def test_async_initializer(self):
-        async def sleepy():
+        async def sleepy(_loop):
             await asyncio.sleep(0)
 
         with self.assertRaises(ValueError) as _:
@@ -185,7 +185,7 @@ class CoreTest(TestCase):
 
     @async_test
     async def test_sync_target(self):
-        def dummy():
+        def dummy(_loop):
             pass
 
         with self.assertRaises(ValueError) as _:


### PR DESCRIPTION
### Description

The event loop running in the process/pool could actually be useful, e.g. register the loop to some library such as logging, so that we can do async logging later.

```
$ make lint test                                                        
python3 -m mypy aiomultiprocess
python3 -m pylint --rcfile .pylint aiomultiprocess setup.py
python3 -m isort --diff --recursive aiomultiprocess setup.py
python3 -m black --check aiomultiprocess
All done! \u2728 \U0001f370 \u2728
7 files would be left unchanged.
python3 -m coverage run -m aiomultiprocess.tests
test_async_initializer (aiomultiprocess.tests.core.CoreTest) ... ok
test_initializer (aiomultiprocess.tests.core.CoreTest) ... ok
test_none (aiomultiprocess.tests.core.CoreTest) ... ok
test_pool (aiomultiprocess.tests.core.CoreTest) ... ok
test_pool_worker (aiomultiprocess.tests.core.CoreTest) ... ok
test_process (aiomultiprocess.tests.core.CoreTest) ... ok
test_process_terminate (aiomultiprocess.tests.core.CoreTest) ... ok
test_process_timeout (aiomultiprocess.tests.core.CoreTest) ... ok
test_raise (aiomultiprocess.tests.core.CoreTest) ... ok
test_spawn_context (aiomultiprocess.tests.core.CoreTest) ... ok
test_sync_target (aiomultiprocess.tests.core.CoreTest) ... ok
test_worker (aiomultiprocess.tests.core.CoreTest) ... ok
test_worker_join (aiomultiprocess.tests.core.CoreTest) ... ok
test_pool_concurrency (aiomultiprocess.tests.perf.PerfTest) ... ok

----------------------------------------------------------------------
Ran 14 tests in 3.003s

OK
Coverage.py warning: No data was collected. (no-data-collected)
python3 -m coverage combine
python3 -m coverage report
Name                      Stmts   Miss Branch BrPart    Cover   Missing
-----------------------------------------------------------------------
aiomultiprocess/core.py     241     24     68     11    88.7%   64, 136, 142-144, 153, 173, 178, 197-203, 221-223, 234, 276-277, 299-300, 414, 431, 444, 466, 123->126, 135->136, 152->153, 195->197, 233->234, 275->276, 413->414, 430->431, 443->444, 457->460, 465->466
-----------------------------------------------------------------------
TOTAL                       245     24     68     11    88.8%
```