### PR TITLE
Fix argument errors in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ async def get(url):
         return await response.text("utf-8")
 
 async def main():
-    p = Worker(target=get, args=("https://jreese.sh", {}))
+    p = Worker(target=get, args=("https://jreese.sh", ))
     response = await p
 
 asyncio.run(main())


### PR DESCRIPTION
### Description

Fix argument errors in the example

```
TypeError: get() takes 1 positional argument but 2 were given
```