### PR TITLE
`make test` is now working for 3.8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 black==19.3b0
 codecov==2.0.15
-coverage==4.5.3
+coverage==4.5.4
 isort==4.3.20
 mypy==0.720
 pylint==2.3.1


### PR DESCRIPTION
### Description
Coverage fixed the issue with multiprocessing on 4.5.4: https://github.com/nedbat/coveragepy/issues/828
The other issue on PyLint/astroid is also fixed, but version bump is not needed as it is not a direct dependency: https://github.com/PyCQA/astroid/issues/675

test plan:
`make lint test` runs fine on 3.8rc
wait for Travis CI

Fixes: #26