### PR TITLE
Better PR/push triggers for actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: Build
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Reduces duplication of builds for PR's by only triggering "push" type builds for master branch and version tags.